### PR TITLE
Correctif pour le support pour le niveau "TRACE"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@villedemontreal/logger",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@villedemontreal/logger",
-      "version": "6.6.0",
+      "version": "6.6.1",
       "license": "MIT",
       "dependencies": {
         "@types/app-root-path": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villedemontreal/logger",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "Logger and logging utilities",
   "main": "dist/src/index.js",
   "typings": "dist/src",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -438,7 +438,9 @@ export class Logger implements ILogger {
       };
     }
 
-    if (level === LogLevel.DEBUG) {
+    if (level === LogLevel.TRACE) {
+      this.pino.trace(this.enhanceLog(messageObjClean));
+    } else if (level === LogLevel.DEBUG) {
       this.pino.debug(this.enhanceLog(messageObjClean));
     } else if (level === LogLevel.INFO) {
       this.pino.info(this.enhanceLog(messageObjClean));


### PR DESCRIPTION
Les précédentes modifications étaient trop optimistes : il ne suffisait pas d'ajuster la fonction `#convertLogLevelToPinoLabelLevel` mais il fallait aussi ajuster la méthode `Logger#log` (responsable de l'appel sous-jacent à pino), bien entendu...